### PR TITLE
Remove reference to _internal/google_news.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,6 @@
   <title>{{ if eq .IsHome true }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
   <meta name="description" content="{{ if ne .Description "" }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
 {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/google_news.html" . }}
   {{ template "_internal/schema.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
   <link rel="canonical" href="{{ .Permalink | absURL }}">


### PR DESCRIPTION
The hugo internal template "google_news.html" was deprecated in version 0.90.0 in 2021 (see: https://github.com/gohugoio/hugo/releases/tag/v0.90.0).

The template was removed in version 0.111.0 in 2023 (see: https://github.com/gohugoio/hugo/releases/tag/v0.111.0).

Using this theme between hugo versions 0.90.0 and 0.111.0 will result in a deprecation warning. Using this theme in version 0.111.0 or after results in the following error:

```Error: html/template:_partials/header.html:10:14: no such template "_internal/google_news.html"```

Since Google News meta tag (news_keywords) hasn't been supported since October 2017, it doesn't make sense to continue to include this template anyway for those using versions of hugo below 0.90.0, if any.